### PR TITLE
Add projectName default

### DIFF
--- a/accelerator.yaml
+++ b/accelerator.yaml
@@ -6,6 +6,12 @@ accelerator:
     - tanzu
 
   options:
+    - name: projectName
+      label: Name
+      description: The name for your new project
+      display: false
+      defaultValue: "new-project"
+
     - name: workloadType
       inputType: text
       label: Workload Type


### PR DESCRIPTION
This will change the default to "new-project" instead of using the accelerator name of "tap-initialize"